### PR TITLE
Send IterationInfo updates from solver thread only once every 10 ms

### DIFF
--- a/TeamProjects/diffusion-solver/ui/dssolverthread.hpp
+++ b/TeamProjects/diffusion-solver/ui/dssolverthread.hpp
@@ -4,11 +4,14 @@
 #include <memory>
 #include <functional>
 #include <diffusioncore>
+#include <chrono>
 
 #include <QMutex>
 #include <QThread>
 
 #include "dssolveriterationinfo.hpp"
+
+using namespace std::chrono;
 
 using diffusioncore::SchemeSolver;
 using diffusioncore::SchemeSolverResult;
@@ -40,12 +43,14 @@ protected:
 private:
     bool AcquireIterationInfo(SchemeSolverIterationInfo& info);
 
+    milliseconds GetMaxUpdateIterationSpan() const { return milliseconds(10); }
+
     QMutex mtx;
     bool solverNeedStop;
     SchemeSolverResult result;
     std::once_flag registerMetaTypeFlag;
     std::shared_ptr<SchemeSolver> solver;
-
+    high_resolution_clock::time_point updateIterationInfoPoint;
 };
 
 #endif // DSSOLVERTHREAD_HPP


### PR DESCRIPTION
В конце расчёта что-то немного всё замирает, в реализации с ```QThread::msleep(SLEEP_INTERVAL_MS);``` этого не было. Возможно стоит поискать, в чём дело, прежде чем мёржить этот реквест.